### PR TITLE
DOC: Added README with installation instructions and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Currently, Fulmar has no automated way to install itself. Fortunately, it's fair
 The following link contains more information about how and where to set up the symbolic link to get Fulmar working:
 http://docs.racket-lang.org/guide/language-collection.html
 
+There's a suite of pseudo-unit/regression tests in the tests/ directory. Currently, you can run tests/main.rkt to test Fulmar.
+
 Use
 ---
 
@@ -55,7 +57,7 @@ Once you've gone through the installation above, you should be able to run Fulma
 
     racket myscript.fmr
 
-If you run tests/main.rkt, it will generate a Fulmar script called test.fmr that you can try out.
+There is a Fulmar script in tests/ called test.fmr that you can try out.
 
 **TODO** Expand this section
 


### PR DESCRIPTION
Here's the first draft of the README. Github renders it rather nicely. I figure the License and Copyright section can be something to the effect of, "Fulmar is licensed under the (L)GPL/MIT/BSD/CRAPL version(s) whatever. See LICENSE for details."
