### PR TITLE
FIX: Angle brackets: Produce foo<bar<baz> > instead of foo<bar<baz>>.

### DIFF
--- a/FulmarAbbreviations.rkt
+++ b/FulmarAbbreviations.rkt
@@ -122,7 +122,7 @@
   (report-backend-or chunk #false))
 (: kernel-call (Chunk NestofChunks * -> Chunk))
 (define (kernel-call name . args)
-  (type-template name (template-list (template-list args))))
+  (concat name (if-empty args empty (apply arg-list sur-anbr "," args))))
 (: device-only (NestofChunks * -> Chunk))
 (define (device-only . chunks)
   (add-spaces '__device__ chunks))

--- a/private/core-chunk.rkt
+++ b/private/core-chunk.rkt
@@ -1,6 +1,7 @@
 #lang typed/racket
 
-(require "fulmar-core.rkt")
+(require "fulmar-core.rkt"
+         "doc/document.rkt")
 
 ;fulmar core chunks - these directly build nekots or use fulmar-core functionality
 
@@ -32,6 +33,15 @@
   (and (pair? lst)
        (= 1 (length lst))))
 
+
+(document not-ends-in->>
+"Helper function for speculative that will return false if the given chunks
+ end in >>.")
+(: not-ends-in->> ((Listof String) -> Boolean))
+(define (not-ends-in->> lst)
+  (match lst
+    [`(,(regexp #rx">>$") . ,_) #f]
+    [_ #t]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;nekot-building chunks;;;;;;;

--- a/standard-chunk.rkt
+++ b/standard-chunk.rkt
@@ -90,12 +90,22 @@ For ANY OTHER INPUT, returns #f.")
           (immediate "}")))
 
 (document sur-anbr
-"Surround a chunk in angle brackets. Same as sur-paren, but with these: <>")
+"Surround a chunk in angle brackets. Same as sur-paren, but with these: <>"
+"This function is designed to avoid producing a \">>\" at the end of the list.
+ Since the predominant use of an anble bracketed list in C++ is for templates,
+ and foo<bar<baz>> is a compiler error, this function works hard to produce
+ foo<bar<baz> > instead. If this is not what you need, consider rolling your
+ own.")
 (: sur-anbr (Chunk * -> Chunk))
 (define (sur-anbr . chunks)
-  (concat (immediate "<")
-          chunks
-          (immediate ">")))
+  (speculative (concat (immediate "<")
+                       chunks
+                       (immediate ">"))
+               not-ends-in->>
+               (concat (immediate "<")
+                       chunks
+                       space
+                       (immediate ">"))))
 
 (document sur-sqbr
 "Surround a chunk in square brackets. Same as sur-paren, but with these: []")

--- a/standard-chunk.rkt
+++ b/standard-chunk.rkt
@@ -91,13 +91,23 @@ For ANY OTHER INPUT, returns #f.")
 
 (document sur-anbr
 "Surround a chunk in angle brackets. Same as sur-paren, but with these: <>"
+"If you need to surround a template list in pointy brackets, use
+ sur-anbr-template instead.")
+(: sur-anbr (Chunk * -> Chunk))
+(define (sur-anbr . chunks)
+  (concat (immediate "<")
+          chunks
+          (immediate ">")))
+
+(document sur-anbr-template
+"Surround a chunk in angle brackets, carefully avoiding C++ parser problems."
 "This function is designed to avoid producing a \">>\" at the end of the list.
  Since the predominant use of an anble bracketed list in C++ is for templates,
  and foo<bar<baz>> is a compiler error, this function works hard to produce
- foo<bar<baz> > instead. If this is not what you need, consider rolling your
- own.")
-(: sur-anbr (Chunk * -> Chunk))
-(define (sur-anbr . chunks)
+ foo<bar<baz> > instead. If this is not what you need, consider using sur-anbr
+ instead.")
+(: sur-anbr-template (Chunk * -> Chunk))
+(define (sur-anbr-template . chunks)
   (speculative (concat (immediate "<")
                        chunks
                        (immediate ">"))
@@ -199,7 +209,7 @@ For ANY OTHER INPUT, returns #f.")
  list with angle brackets.")
 (: template-list (NestofChunks * -> Chunk))
 (define (template-list . chunks)
-  (apply arg-list sur-anbr "," chunks))
+  (apply arg-list sur-anbr-template "," chunks))
 
 (document body-list
 "Takes a separator chunk and a list of chunks, separates the chunks with the


### PR DESCRIPTION
This should fix the >> compiler parse error that Hao was running into.